### PR TITLE
Included paragonie/random_compat ^9.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "guzzlehttp/psr7": "^2.0",
     "illuminate/collections": "^8.0",
     "league/oauth2-client": "^2.6",
-    "paragonie/random_compat": "^2 || ^9.99",
+    "paragonie/random_compat": "9.99.99",
     "psr/cache": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
@@ -48,5 +48,8 @@
     "allow-plugins": {
       "bamarni/composer-bin-plugin": true
     }
+  },
+  "replace": {
+    "paragonie/random_compat": "9.99.99"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,5 @@
     "allow-plugins": {
       "bamarni/composer-bin-plugin": true
     }
-  },
-  "replace": {
-    "paragonie/random_compat": "9.99.99"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "guzzlehttp/psr7": "^2.0",
     "illuminate/collections": "^8.0",
     "league/oauth2-client": "^2.6",
-    "paragonie/random_compat": "9.99.99",
+    "paragonie/random_compat": "^9.99",
     "psr/cache": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "guzzlehttp/psr7": "^2.0",
     "illuminate/collections": "^8.0",
     "league/oauth2-client": "^2.6",
-    "paragonie/random_compat": "^2",
+    "paragonie/random_compat": "^2 || ^9.99",
     "psr/cache": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bugfix
| Ticket           | [Jira/GitHub reference](https://dvsa.atlassian.net/browse/VOL-3384)

**Description of the change:**
Changes the require for **paragonie/random_compat** to allow **^9.99** in line with dependancy **thephpleague/oauth2-client**
