### PR TITLE
Ensure resourceOwnerData is array (recursively)

### DIFF
--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -451,7 +451,7 @@ class GovUkAccount extends AbstractProvider
         if (!$encoded) {
             throw new \JsonException('Could not encode $response');
         }
-        $response = json_decode(json_encode($encoded), true);
+        $response = json_decode($encoded, true);
 
         return new GovUkAccountUser($response);
     }

--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -446,6 +446,7 @@ class GovUkAccount extends AbstractProvider
                 $token->getIdTokenClaims()
             );
         }
+        $response = json_decode(json_encode($response), true);
 
         return new GovUkAccountUser($response);
     }

--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -446,7 +446,12 @@ class GovUkAccount extends AbstractProvider
                 $token->getIdTokenClaims()
             );
         }
-        $response = json_decode(json_encode($response), true);
+
+        $encoded = json_encode($response);
+        if (!$encoded) {
+            throw new \JsonException('Could not encode $response');
+        }
+        $response = json_decode(json_encode($encoded), true);
 
         return new GovUkAccountUser($response);
     }

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -333,6 +333,35 @@ class GovUkAccountTest extends TestCase
         $this->assertEquals('test-subject', $userInfo->getId(), "getID does not return subject");
     }
 
+    public function testGetResourceOwnerStdClassReturnedAsArray(): void
+    {
+        $provider = $this->getProvider();
+
+        $obj = new \stdClass();
+        $obj->testProp = 'testValue';
+
+        $this->httpClient
+            ->expects('send')
+            ->once()
+            ->andReturn(new Response(200, [], json_encode([
+                'sub' => 'test-subject',
+                'test' => $obj
+            ])));
+
+        $token = new AccessToken([
+            'access_token' => $this->createAccessToken(),
+            'id_token' => $this->createIdToken($provider->setNonce())
+        ], $provider);
+
+        $userInfo = $provider->getResourceOwner($token);
+        $this->assertInstanceOf(GovUkAccountUser::class, $userInfo);
+        $this->assertIsArray($userInfo->getField('test'));
+        $this->assertArrayHasKey('testProp', $userInfo->getField('test'));
+        $this->assertEquals('testValue' ,$userInfo->getField('test')['testProp']);
+        $this->assertEquals('test-subject', $userInfo->getField('sub'));
+        $this->assertEquals('test-subject', $userInfo->getId(), "getID does not return subject");
+    }
+
     /**
      * @dataProvider dataProviderValidateCoreIdentityToken
      */

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -357,7 +357,7 @@ class GovUkAccountTest extends TestCase
         $this->assertInstanceOf(GovUkAccountUser::class, $userInfo);
         $this->assertIsArray($userInfo->getField('test'));
         $this->assertArrayHasKey('testProp', $userInfo->getField('test'));
-        $this->assertEquals('testValue' ,$userInfo->getField('test')['testProp']);
+        $this->assertEquals('testValue', $userInfo->getField('test')['testProp']);
         $this->assertEquals('test-subject', $userInfo->getField('sub'));
         $this->assertEquals('test-subject', $userInfo->getId(), "getID does not return subject");
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bugfix

**Description of the change:**
Ensures when creating a user object from a JWT::decode() that we have associative arrays instead of stdClass().
