### PR TITLE
Do not overwrite JWT claim for UserInfo

### DIFF
--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -441,7 +441,7 @@ class GovUkAccount extends AbstractProvider
         $coreIdentityToken = $response[GovUkAccountUser::KEY_CLAIMS_CORE_IDENTITY] ?? null;
         if (!empty($coreIdentityToken)) {
             // Replace JWT with Validated Claim Array
-            $response[GovUkAccountUser::KEY_CLAIMS_CORE_IDENTITY] = $this->validateCoreIdentityClaim(
+            $response[GovUkAccountUser::KEY_CLAIMS_CORE_IDENTITY_DECODED] = $this->validateCoreIdentityClaim(
                 $coreIdentityToken,
                 $token->getIdTokenClaims()
             );

--- a/src/Provider/GovUkAccountUser.php
+++ b/src/Provider/GovUkAccountUser.php
@@ -8,6 +8,7 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 class GovUkAccountUser implements ResourceOwnerInterface, JsonSerializable
 {
     public const KEY_CLAIMS_CORE_IDENTITY = 'https://vocab.account.gov.uk/v1/coreIdentityJWT';
+    public const KEY_CLAIMS_CORE_IDENTITY_DECODED = 'https://vocab.account.gov.uk/v1/coreIdentityDecoded';
 
     protected array $data = [];
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Type             | Bugfix

**Description of the change:**
createResourceOwner() no longer overwrites the original value and insteads creates a Decoded varient
