### PR TITLE
fix: fix string support of identity assurance key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "ext-json": "*",
     "firebase/php-jwt": "^6.3",
     "guzzlehttp/guzzle": "^7.5",
-    "guzzlehttp/psr7": "^2.0",
+    "guzzlehttp/psr7": "^2.4.5",
     "illuminate/collections": "^8.0",
     "league/oauth2-client": "^2.6",
     "paragonie/random_compat": "^9.99",

--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -75,7 +75,7 @@ class GovUkAccount extends AbstractProvider
     private function parseIdentityAssuranceKey($jwk): Key
     {
         if (!is_array($jwk)) {
-            $jwk = json_decode($jwk);
+            $jwk = json_decode($jwk, true);
         }
 
         $key = JWK::parseKey($jwk);

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -103,6 +103,23 @@ class GovUkAccountTest extends TestCase
     }
 
     /**
+     * @doesNotPerformAssertions
+     */
+    public function testStringIdentityAssurancePublicKey(): void
+    {
+        $options = [
+            'keys' => [
+                'algorithm' => 'RS256',
+                'private_key' => static::CLIENT_PRIVATE_KEY,
+                'identity_assurance_public_key' => json_encode(static::SERVICE_PUBLIC_KEY_JWK['keys'][1]),
+            ]
+        ];
+
+        // The logic that is being tested happens in the `__construct` method - `parseIdentityAssuranceKey`.
+        $this->getProvider($options);
+    }
+
+    /**
      * @dataProvider dataProviderSetGetNonce
      */
     public function testSetGetNonce(?string $value): void


### PR DESCRIPTION
Code implies support of a string identity assurance key, but the `json_decode` returns an object. `JWK::parseKey` requires an array.
