### PR TITLE
feat: core identity uses DID for verification and cache support

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [league_oauth2_client]: https://oauth2-client.thephpleague.com/
 [govuk_account]: https://www.sign-in.service.gov.uk/
 
-GOV.UK Account (OAuth2 Provider)
+GOV.UK One Login (OAuth2 Provider)
 ===================================
 A provider (based on [PHP League OAuth2-Client][league_oauth2_client]) to interact with [GOV.UK Account][govuk_account].
 
@@ -24,17 +24,20 @@ You may want to refer to the documentation provided at [PHP League OAuth2-Client
 When instantiating the provider, the constructor accepts **additional** attributes defined in `array $options = []` which are specific for this provider; in addition to the default options provided by the AbstractProvider ([PHP League OAuth2-Client][league_oauth2_client]).
 
 ```php
+'base_uri' => 'https://oidc.integration.account.gov.uk', // Base URI for the GOV.UK One Login API 
 'discovery_endpoint' => 'https://oidc.integration.account.gov.uk/.well-known/openid-configuration', // Endpoint for OIDC discovery
-'client_id' => '', // Client ID issued by GOV.UK Account
+'core_identity_did_document_url' => 'https://identity.integration.account.gov.uk/.well-known/did.json', // The DID document URL used to verify the JWTCoreIdentity token from UserDetails endpoint
+'client_id' => '', // Client ID issued by GOV.UK One Login
 'keys' => [
-  'algorithm' => '', // Algorithm for private_key
-  'private_key' => '', // Private key used to encode assertion when obtaining access token (public key must be shared with GOV.UK Account)
-  'identity_assurance_public_key' => [], // THe public key used to verify the JWTCoreIdentity token from UserDetails endpoint (if initial flow included identity assurance)
+    'algorithm' => 'RS256', // Algorithm for private_key
+    'private_key' => '', // Private key used to encode assertion when obtaining access token (public key must be shared with GOV.UK One Login)
+    'public_key' => '', // Public key used to decode assertion when obtaining access token
 ],
 'redirect_uri' => [
-  'logged_in' => '', // The url used for redirection back to the service
+    'logged_in' => '', // The url used for redirection back to the service
+    'logged_out' => '', // The url used for redirection back to the service
 ],
-'expected_core_identity_issuer' => 'identity.integration.account.gov.uk', // Issuer for JWTCoreIdentity token
+'expected_core_identity_issuer' => 'https://identity.integration.account.gov.uk/', // Issuer for JWTCoreIdentity token
 ```
 
 Contributing

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "dvsa/php-govuk-account",
-  "description": "A league/oauth2-client provider for GOV.UK Account",
+  "description": "A league/oauth2-client provider for GOV.UK One Login",
   "type": "library",
   "license": [
     "MIT"
@@ -14,6 +14,7 @@
   "keywords": [
     "govuk",
     "signin",
+    "onelogin",
     "sdk",
     "dvsa"
   ],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,5 @@ parameters:
     level: max
     paths:
         - src
+    ignoreErrors:
+        - '#Psr\\Cache\\InvalidArgumentException is not subtype of Throwable#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,5 +25,10 @@
                 <file name="src/Provider/GovUkAccount.php" />
             </errorLevel>
         </RedundantPropertyInitializationCheck>
+        <InvalidThrow>
+            <errorLevel type="suppress">
+                <referencedClass name="Psr\Cache\InvalidArgumentException" />
+            </errorLevel>
+        </InvalidThrow>
     </issueHandlers>
 </psalm>

--- a/src/Helper/CachedHttpClientWrapper.php
+++ b/src/Helper/CachedHttpClientWrapper.php
@@ -4,6 +4,7 @@ namespace Dvsa\GovUkAccount\Helper;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
@@ -25,7 +26,7 @@ class CachedHttpClientWrapper
     /**
      * @throws GuzzleException
      * @throws InvalidArgumentException
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function sendGetRequest(string $url, array $options = [], int $cacheTtlSeconds = self::DEFAULT_CACHE_TTL_SECONDS): array
     {
@@ -40,7 +41,7 @@ class CachedHttpClientWrapper
 
         $parsedResponse = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 
-        if ($this->cache instanceof CacheItemPoolInterface) {
+        if ($this->cache instanceof CacheItemPoolInterface && $cacheItem) {
             $cacheItem->expiresAfter($cacheTtlSeconds);
             $cacheItem->set(serialize($parsedResponse));
             $this->cache->save($cacheItem);

--- a/src/Helper/CachedHttpClientWrapper.php
+++ b/src/Helper/CachedHttpClientWrapper.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Dvsa\GovUkAccount\Helper;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+
+class CachedHttpClientWrapper
+{
+    public const DEFAULT_CACHE_TTL_SECONDS = 3600;
+    public const CACHE_KEY_PREFIX = 'govuk-one-login-oauth2-provider-http-response-';
+
+    private ClientInterface $httpClient;
+    private ?CacheItemPoolInterface $cache;
+
+    public function __construct(ClientInterface $httpClient, ?CacheItemPoolInterface $cache)
+    {
+        $this->httpClient = $httpClient;
+        $this->cache = $cache;
+    }
+
+    /**
+     * @throws GuzzleException
+     * @throws InvalidArgumentException
+     * @throws \JsonException
+     */
+    public function sendGetRequest(string $url, array $options = [], int $cacheTtlSeconds = self::DEFAULT_CACHE_TTL_SECONDS): array
+    {
+        $cacheKey = self::CACHE_KEY_PREFIX . sha1($url);
+        $cacheItem = $this->cache?->getItem($cacheKey);
+
+        if ($cacheItem && $cacheItem->isHit()) {
+            return unserialize($cacheItem->get());
+        }
+
+        $response = $this->httpClient->request('GET', $url, $options);
+
+        $parsedResponse = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+
+        if ($this->cache instanceof CacheItemPoolInterface) {
+            $cacheItem->expiresAfter($cacheTtlSeconds);
+            $cacheItem->set(serialize($parsedResponse));
+            $this->cache->save($cacheItem);
+        }
+
+        return $parsedResponse;
+    }
+}

--- a/src/Helper/CachedHttpClientWrapper.php
+++ b/src/Helper/CachedHttpClientWrapper.php
@@ -8,6 +8,7 @@ use JsonException;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 class CachedHttpClientWrapper
 {
@@ -25,7 +26,7 @@ class CachedHttpClientWrapper
 
     /**
      * @throws GuzzleException
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException&Throwable
      * @throws JsonException
      */
     public function sendGetRequest(string $url, array $options = [], int $cacheTtlSeconds = self::DEFAULT_CACHE_TTL_SECONDS): array

--- a/src/Helper/CachedHttpClientWrapper.php
+++ b/src/Helper/CachedHttpClientWrapper.php
@@ -26,7 +26,7 @@ class CachedHttpClientWrapper
 
     /**
      * @throws GuzzleException
-     * @throws InvalidArgumentException&Throwable
+     * @throws InvalidArgumentException
      * @throws JsonException
      */
     public function sendGetRequest(string $url, array $options = [], int $cacheTtlSeconds = self::DEFAULT_CACHE_TTL_SECONDS): array

--- a/src/Helper/DidDocumentParser.php
+++ b/src/Helper/DidDocumentParser.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Dvsa\GovUkAccount\Helper;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\Key;
+
+class DidDocumentParser
+{
+    /**
+     * This method parses a DID document from a JSON string into an array.
+     *
+     * @param string $didDocument The DID document as a JSON string
+     * @return array
+     */
+    public static function parse(string $didDocument): array
+    {
+        $didDocument = json_decode($didDocument, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException('Invalid DID document');
+        }
+
+        return $didDocument;
+    }
+
+    /**
+     * This method attempts to extract JWKs from a DID document and parse them into Key objects.
+     *
+     * @param string|array $didDocument The DID document as a JSON string or an array
+     * @return Key[]
+     */
+    public static function parseToKeyArray(string|array $didDocument): array
+    {
+        if (is_string($didDocument)) {
+            $didDocument = self::parse($didDocument);
+        }
+
+        $keys = [];
+
+        if(!isset($didDocument['assertionMethod'])) {
+            throw new \InvalidArgumentException('DID document has no assertion method');
+        }
+
+        foreach ($didDocument['assertionMethod'] as $key) {
+            if (($key['type'] ?? null) !== 'JsonWebKey') {
+                continue;
+            }
+            if (($key['publicKeyJwk']['alg'] ?? null) == null) {
+                continue;
+            }
+
+            // Inject 'kid' into the JWK if not present
+            if (!isset($key['publicKeyJwk']['kid'])) {
+                $key['publicKeyJwk']['kid'] = $key['id'];
+            }
+
+            $parsedKey = JWK::parseKey($key['publicKeyJwk'], $key['publicKeyJwk']['alg']);
+            if ($parsedKey === null) {
+                continue;
+            }
+
+            $keys[$key['id']] = $parsedKey;
+        }
+
+        if (empty($keys)) {
+            throw new \InvalidArgumentException('No valid keys found in DID document');
+        }
+
+        return $keys;
+    }
+}

--- a/src/Helper/DidDocumentParser.php
+++ b/src/Helper/DidDocumentParser.php
@@ -38,7 +38,7 @@ class DidDocumentParser
 
         $keys = [];
 
-        if(!isset($didDocument['assertionMethod'])) {
+        if (!isset($didDocument['assertionMethod'])) {
             throw new \InvalidArgumentException('DID document has no assertion method');
         }
 

--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -224,15 +224,6 @@ class GovUkAccount extends AbstractProvider
      */
     public function loadJwks(string $jwksUrl): ArrayAccess
     {
-        if ($this->cache instanceof CacheItemPoolInterface) {
-            return new CachedKeySet(
-                $jwksUrl,
-                $this->getHttpClient(),
-                new HttpFactory(),
-                $this->cache
-            );
-        }
-
         try {
             $response = $this->cachedHttpClientWrapper->sendGetRequest(url: $jwksUrl, cacheTtlSeconds: 3600);
         } catch (GuzzleException $e) {

--- a/src/Provider/GovUkAccount.php
+++ b/src/Provider/GovUkAccount.php
@@ -462,7 +462,7 @@ class GovUkAccount extends AbstractProvider
         if ($issuer !== $this->expectedCoreIdentityIssuer) {
             throw new InvalidTokenException(sprintf(
                 'The issuer (iss) for CoreIdentityJWT is invalid: %s (expecting %s)',
-                $issuer,
+                $issuer ?? 'null',
                 $this->expectedCoreIdentityIssuer
             ));
         }
@@ -471,7 +471,7 @@ class GovUkAccount extends AbstractProvider
         if ($audience !== $this->clientId) {
             throw new InvalidTokenException(sprintf(
                 'The audience (aud) for CoreIdentityJWT is invalid: %s (expecting %s)',
-                $audience,
+                $audience ?? 'null',
                 $this->clientId
             ));
         }
@@ -480,7 +480,7 @@ class GovUkAccount extends AbstractProvider
         if ($subject !== $idTokenClaims['sub']) {
             throw new InvalidTokenException(sprintf(
                 'The subject (sub) for CoreIdentityJWT is invalid and does not match the subject for the ID Token: %s (expecting %s)',
-                $subject,
+                $subject ?? 'null',
                 $idTokenClaims['sub']
             ));
         }

--- a/src/Token/GovUkAccountUser.php
+++ b/src/Token/GovUkAccountUser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dvsa\GovUkAccount\Provider;
+namespace Dvsa\GovUkAccount\Token;
 
 use JsonSerializable;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;

--- a/test/Helper/CachedHttpClientWrapperTest.php
+++ b/test/Helper/CachedHttpClientWrapperTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Helper;
+
+use Dvsa\GovUkAccount\Helper\CachedHttpClientWrapper;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+
+class CachedHttpClientWrapperTest extends TestCase
+{
+    protected ClientInterface $httpClient;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->httpClient = m::mock(ClientInterface::class, \Psr\Http\Client\ClientInterface::class);
+    }
+
+    public function testSendRequestWithCacheHit()
+    {
+        $cache = m::mock(CacheItemPoolInterface::class);
+        $cacheItem = m::mock(\Psr\Cache\CacheItemInterface::class);
+        $cacheKey = CachedHttpClientWrapper::CACHE_KEY_PREFIX . sha1('http://example.com');
+        $cacheValue = ['key' => 'value'];
+
+        $cache->shouldReceive('getItem')
+            ->with($cacheKey)
+            ->andReturn($cacheItem);
+
+        $cacheItem->shouldReceive('isHit')
+            ->andReturn(true);
+
+        $cacheItem->shouldReceive('get')
+            ->andReturn(serialize($cacheValue));
+
+        $wrapper = new CachedHttpClientWrapper($this->httpClient, $cache);
+        $result = $wrapper->sendGetRequest('http://example.com');
+
+        $this->assertSame($cacheValue, $result);
+    }
+
+    public function testSendRequestWithCacheMiss()
+    {
+        $cache = m::mock(CacheItemPoolInterface::class);
+        $cacheItem = m::mock(\Psr\Cache\CacheItemInterface::class);
+        $cacheKey = CachedHttpClientWrapper::CACHE_KEY_PREFIX . sha1('http://example.com');
+        $cacheValue = ['key' => 'value'];
+        $response = new Response(200, [], json_encode($cacheValue));
+
+        $cache->shouldReceive('getItem')
+            ->with($cacheKey)
+            ->andReturn($cacheItem);
+
+        $cacheItem->shouldReceive('isHit')
+            ->andReturn(false);
+
+        $this->httpClient->shouldReceive('request')
+            ->with('GET', 'http://example.com', [])
+            ->andReturn($response);
+
+        $cacheItem->shouldReceive('expiresAfter')
+            ->with(CachedHttpClientWrapper::DEFAULT_CACHE_TTL_SECONDS);
+
+        $cacheItem->shouldReceive('set')
+            ->with(serialize($cacheValue));
+
+        $cache->shouldReceive('save')
+            ->with($cacheItem);
+
+        $wrapper = new CachedHttpClientWrapper($this->httpClient, $cache);
+        $result = $wrapper->sendGetRequest('http://example.com');
+
+        $this->assertSame($cacheValue, $result);
+    }
+
+    public function testSendRequestWithCacheMissAndCustomTtl()
+    {
+        $cache = m::mock(CacheItemPoolInterface::class);
+        $cacheItem = m::mock(\Psr\Cache\CacheItemInterface::class);
+        $cacheKey = CachedHttpClientWrapper::CACHE_KEY_PREFIX . sha1('http://example.com');
+        $cacheValue = ['key' => 'value'];
+        $response = new Response(200, [], json_encode($cacheValue));
+
+        $cache->shouldReceive('getItem')
+            ->with($cacheKey)
+            ->andReturn($cacheItem);
+
+        $cacheItem->shouldReceive('isHit')
+            ->andReturn(false);
+
+        $this->httpClient->shouldReceive('request')
+            ->with('GET', 'http://example.com', [])
+            ->andReturn($response);
+
+        $cacheItem->shouldReceive('expiresAfter')
+            ->with(1800);
+
+        $cacheItem->shouldReceive('set')
+            ->with(serialize($cacheValue));
+
+        $cache->shouldReceive('save')
+            ->with($cacheItem);
+
+        $wrapper = new CachedHttpClientWrapper($this->httpClient, $cache);
+        $result = $wrapper->sendGetRequest('http://example.com', [], 1800);
+
+        $this->assertSame($cacheValue, $result);
+    }
+
+    public function testSendRequestWithNoCacheSet(): void
+    {
+        $wrapper = new CachedHttpClientWrapper($this->httpClient, null);
+        $cacheValue = ['key' => 'value'];
+        $response = new Response(200, [], json_encode($cacheValue));
+
+        $this->httpClient->shouldReceive('request')
+            ->with('GET', 'http://example.com', [])
+            ->andReturn($response);
+
+        $result = $wrapper->sendGetRequest('http://example.com');
+
+        $this->assertSame($cacheValue, $result);
+    }
+}

--- a/test/Helper/DidDocumentParserTest.php
+++ b/test/Helper/DidDocumentParserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Helper;
+
+use Dvsa\GovUkAccount\Helper\DidDocumentParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Dvsa\GovUkAccount\Helper\DidDocumentParser
+ */
+class DidDocumentParserTest extends TestCase
+{
+    public function testParse()
+    {
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        $parsed = DidDocumentParser::parse($didDocument);
+
+        $this->assertEquals([
+            'assertionMethod' => [
+                [
+                    'id' => '#key-1',
+                    'type' => 'JsonWebKey',
+                    'publicKeyJwk' => [
+                        'alg' => 'ES256',
+                        'crv' => 'P-256',
+                        'kty' => 'EC',
+                        'use' => 'sig',
+                        'x' => 'x',
+                        'y' => 'y',
+                    ],
+                ],
+            ],
+        ], $parsed);
+    }
+
+    public function testParseToKeyArray()
+    {
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        $parsed = DidDocumentParser::parseToKeyArray($didDocument);
+
+        $this->assertCount(1, $parsed);
+        $this->assertContainsOnlyInstancesOf(\Firebase\JWT\Key::class, $parsed);
+    }
+
+    public function testParseToKeyArrayWithInvalidDocument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('DID document has no assertion method');
+
+        DidDocumentParser::parseToKeyArray('{"assertionMethodTypo":[]}');
+    }
+
+    public function testParseToKeyArrayWithNoValidJsonWebKeyTypes()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No valid keys found in DID document');
+
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"NotJsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        DidDocumentParser::parseToKeyArray($didDocument);
+    }
+
+    public function testParseToKeyArrayWithNoAlg()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No valid keys found in DID document');
+
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        DidDocumentParser::parseToKeyArray($didDocument);
+    }
+
+    public function testParseToKeyArrayInvalidKeysAreOmittedButValidOnesRemain()
+    {
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}},{"id":"#key-2","type":"NotJsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        $parsed = DidDocumentParser::parseToKeyArray($didDocument);
+
+        $this->assertCount(1, $parsed);
+        $this->assertContainsOnlyInstancesOf(\Firebase\JWT\Key::class, $parsed);
+    }
+
+    public function testParseToKeyArrayMultipleKeysAreParsed()
+    {
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}},{"id":"#key-2","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        $parsed = DidDocumentParser::parseToKeyArray($didDocument);
+
+        $this->assertCount(2, $parsed);
+        $this->assertContainsOnlyInstancesOf(\Firebase\JWT\Key::class, $parsed);
+    }
+
+    public function testParseToKeyArrayWhereArrayIndexIsKeyIds()
+    {
+        $didDocument = '{"assertionMethod":[{"id":"#key-1","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}},{"id":"#key-2","type":"JsonWebKey","publicKeyJwk":{"alg":"ES256","crv":"P-256","kty":"EC","use":"sig","x":"x","y":"y"}}]}';
+        $parsed = DidDocumentParser::parseToKeyArray($didDocument);
+
+        $this->assertArrayHasKey('#key-1', $parsed);
+        $this->assertArrayHasKey('#key-2', $parsed);
+    }
+}

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -3,15 +3,15 @@
 namespace Provider;
 
 use Dvsa\GovUkAccount\Exception\InvalidTokenException;
-use Dvsa\GovUkAccount\Provider\GovUkAccount as GovUkAccountProvider;
-use Dvsa\GovUkAccount\Provider\GovUkAccountUser;
+use Dvsa\GovUkAccount\Provider\GovUkAccount;
 use Dvsa\GovUkAccount\Token\AccessToken;
+use Dvsa\GovUkAccount\Token\GovUkAccountUser;
 use Firebase\JWT\CachedKeySet;
 use Firebase\JWT\JWT;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
 class GovUkAccountTest extends TestCase
@@ -19,7 +19,7 @@ class GovUkAccountTest extends TestCase
     // Generated ES256 (P256) (SHA256) keys for unit tests
     const CLIENT_PUBLIC_KEY = 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFSU1MWXlXcjZnRDRjTzRhRU40emRKZWo2eXp0UwpQWHdLUTRjcWM0YmcvZ2hZY1FFeS9PcnFoV3VNNzJvL3NaaFB6ZXo1Tjk5cjhxVzlrRWdKTk4wMlJnPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t';
     const CLIENT_PRIVATE_KEY = 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1FRUNBUUF3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRUp6QWxBZ0VCQkNCeXBGZk54Mk1jTWNiamtPcEgKT2IxdVlsNDRaOVJmWmE5MjYxUXc5dEZia1E9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t';
-    const SERVICE_PUBLIC_KEU = 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFZGNxQkwrTUh2TWNldi8wWHI3ZFhvOXdQVFpqLwpuZnA1WGg0dnB4MXJneHdHVHpFbmxuQXFVOVkzdXN4Rml6a2g0VkdkVWc1S3JNSmpnd2NrWWVmdG9BPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==';
+    const SERVICE_PUBLIC_KEY = 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFZGNxQkwrTUh2TWNldi8wWHI3ZFhvOXdQVFpqLwpuZnA1WGg0dnB4MXJneHdHVHpFbmxuQXFVOVkzdXN4Rml6a2g0VkdkVWc1S3JNSmpnd2NrWWVmdG9BPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==';
     const SERVICE_PRIVATE_KEY = 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1FRUNBUUF3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRUp6QWxBZ0VCQkNETExrUlQ3UGVpaklERm02SEMKZGlYYXJmbjY0emxTNDhreXdJMWE1em1NMHc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t';
     const SERVICE_CORE_IDENTITY_CLAIM_PUBLIC_KEY = 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFSm1sbW92MmtYTHB4NVd2YzMxVHRIZGZjRktNYwp6dGliZHNraHFCL1lSSDEzV2dOOXBpTkVKRUJGS3JjZGQ5SEE4d1VEWDdsMjN5bFB4REVqZnRROXh3PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t';
     const SERVICE_CORE_IDENTITY_CLAIM_PRIVATE_KEY = 'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1FRUNBUUF3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRUp6QWxBZ0VCQkNDSkh1bHVwZ3Bqclo5MitaalUKZ1E5RmY4YVhxNkZIek1EeVJuejNHY1pjNGc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0t';
@@ -54,7 +54,7 @@ class GovUkAccountTest extends TestCase
         $this->httpClient = m::mock(ClientInterface::class, \Psr\Http\Client\ClientInterface::class);
     }
 
-    protected function getProvider(array $options = [], array $collaborators = [], CacheItemPoolInterface $cache = null): GovUkAccountProvider
+    protected function getProvider(array $options = [], array $collaborators = [], CacheItemPoolInterface $cache = null): GovUkAccount
     {
         $options = array_merge([
             'client_id' => 'mock_client_id',
@@ -64,26 +64,42 @@ class GovUkAccountTest extends TestCase
             'keys' => [
                 'algorithm' => 'RS256',
                 'private_key' => static::CLIENT_PRIVATE_KEY,
-                'identity_assurance_public_key' => static::SERVICE_PUBLIC_KEY_JWK['keys'][1],
             ],
+            'core_identity_did_document_url' => 'https://iodc.example/.well-known/did.json',
             'expected_core_identity_issuer' => 'oidc.example',
             'discovery_endpoint' => 'https://iodc.example/.well-known/openid-configuration',
         ], $options);
 
-        $provider = new GovUkAccountProvider($options, $collaborators, $cache);
+        $provider = new GovUkAccount($options, $collaborators, $cache);
 
         $this->httpClient
             ->expects('request')
             ->once()
-            ->withArgs(['GET', 'https://iodc.example/.well-known/openid-configuration'])
+            ->withArgs(['GET', 'https://iodc.example/.well-known/openid-configuration', []])
             ->andReturn(new Response(200, [], json_encode($this->getOpenIdConfiguration())))
             ->byDefault();
 
         $this->httpClient
             ->expects('request')
             ->once()
-            ->withArgs(['GET', 'https://oidc.example/.well-known/jwks.json'])
+            ->withArgs(['GET', 'https://oidc.example/.well-known/jwks.json', []])
             ->andReturn(new Response(200, [], json_encode(static::SERVICE_PUBLIC_KEY_JWK)))
+            ->byDefault();
+
+        $this->httpClient
+            ->expects('request')
+            ->once()
+            ->withArgs(['GET', 'https://iodc.example/.well-known/did.json', []])
+            ->andReturn(new Response(200, [], json_encode([
+                    'assertionMethod' => [
+                        [
+                            'id' => 'swfvlyjqVu0Budk52Fl95nN7jPWGJ1CHPdY-Q5itATc',
+                            'type' => 'JsonWebKey',
+                            'publicKeyJwk' => static::SERVICE_PUBLIC_KEY_JWK['keys'][1],
+                        ],
+                    ],
+                ]))
+            )
             ->byDefault();
 
         $provider->setHttpClient($this->httpClient);
@@ -392,8 +408,13 @@ class GovUkAccountTest extends TestCase
 
         $provider = $this->getProvider();
 
+        // Mock send, with request object with property path as /userinfo
+
         $this->httpClient
             ->expects('send')
+            ->with(m::on(function ($request) {
+                return $request->getUri()->getPath() === '/userinfo';
+            }))
             ->once()
             ->andReturn(new Response(200, [], json_encode([
                 'sub' => 'test-subject',
@@ -473,9 +494,10 @@ class GovUkAccountTest extends TestCase
     {
         return JWT::encode(array_merge([
             'sub' => 'test-sub',
+            'aud' => 'mock_client_id',
             'iss' => 'oidc.example',
             'exp' => (new \DateTimeImmutable())->getTimestamp() + 9000,
             'iat' => (new \DateTimeImmutable())->getTimestamp() - 10,
-        ], $payload), base64_decode(static::SERVICE_CORE_IDENTITY_CLAIM_PRIVATE_KEY), 'ES256');
+        ], $payload), base64_decode(static::SERVICE_CORE_IDENTITY_CLAIM_PRIVATE_KEY), 'ES256', 'swfvlyjqVu0Budk52Fl95nN7jPWGJ1CHPdY-Q5itATc');
     }
 }

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -443,15 +443,6 @@ class GovUkAccountTest extends TestCase
         ];
     }
 
-    public function testLoadJwksRespectsCacheItemPoolInterfaceAndReturnsCachedKeySet(): void
-    {
-        $cacheObject = m::mock(CacheItemPoolInterface::class)->makePartial();
-
-        $provider = $this->getProvider([], [], $cacheObject);
-
-        $this->assertInstanceOf(CachedKeySet::class, $provider->loadJwks('test'));
-    }
-
     protected function createAccessToken(array $payload = []): string
     {
         return JWT::encode(array_merge([

--- a/test/Provider/GovUkAccountTest.php
+++ b/test/Provider/GovUkAccountTest.php
@@ -98,8 +98,7 @@ class GovUkAccountTest extends TestCase
                             'publicKeyJwk' => static::SERVICE_PUBLIC_KEY_JWK['keys'][1],
                         ],
                     ],
-                ]))
-            )
+                ])))
             ->byDefault();
 
         $provider->setHttpClient($this->httpClient);


### PR DESCRIPTION
### Description
- Core Identity Token verification uses DID document instead of hard coded public key (as per [introduction of rotating public keys](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#understand-the-core-identity-signing-key-rotations)).
  - Removed config property `keys` -> `identity_assurance_public_key`
  - Added config property `core_identity_did_document_url`
- Cache Support added for:
  - Discovery endpoint
  - DID document
  - JWKs endpoint
- Bumped to `actions/checkout@v4` in workflows.
- `aud` is checked when verifying Core Identity JWT.

### Ticket
https://dvsa.atlassian.net/browse/VOL-5837
