### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "guzzlehttp/psr7": "^2.4.5",
     "illuminate/collections": "^8.0",
     "league/oauth2-client": "^2.6",
-    "paragonie/random_compat": "^9.99",
     "psr/cache": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^9.99`, but also `php: ^8.2`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?